### PR TITLE
Updated dashboard link setting

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -85,6 +85,8 @@ daskhub:
           # The daskhub helm chart doesn't correctly handle hub.baseUrl.
           # DASK_GATEWAY__PUBLIC_ADDRESS set via terraform
           c.KubeSpawner.environment["DASK_GATEWAY__ADDRESS"] = "http://proxy-http:8000/compute/services/dask-gateway/"
+        02-set-dask-gateway-public-address: |
+          c.KubeSpawner.environment['DASK_GATEWAY__PUBLIC_ADDRESS'] = 'https://${jupyterhub_host}/compute/services/dask-gateway/'
         templates: |
           c.JupyterHub.template_paths.insert(0, "/etc/jupyterhub/templates")
         pre_spawn_hook: |

--- a/terraform/resources/hub.tf
+++ b/terraform/resources/hub.tf
@@ -18,7 +18,7 @@ resource "helm_release" "dhub" {
   create_namespace = true
 
   values = [
-    "${file("../../helm/values.yaml")}",
+    "${templatefile("../../helm/values.yaml", { jupyterhub_host = var.jupyterhub_host })}",
     "${file("../../helm/jupyterhub_opencensus_monitor.yaml")}",
     "${templatefile("../../helm/profiles.yaml", { python_image = var.python_image, r_image = var.r_image, gpu_pytorch_image = var.gpu_pytorch_image, qgis_image = var.qgis_image })}"
   ]
@@ -77,11 +77,6 @@ resource "helm_release" "dhub" {
   set {
     name  = "daskhub.jupyterhub.hub.services.opencensus-monitoring.environment.JUPYTERHUB_ENVIRONMENT"
     value = var.environment
-  }
-
-  set {
-    name  = "daskhub.jupyterhub.hub.config.extraConfig.01-set-dask-gateway-public-address"
-    value = "c.KubeSpawner.environment['DASK_GATEWAY__PUBLIC_ADDRESS'] = 'https://${var.jupyterhub_host}/compute/services/dask-gateway/'"
   }
 
   set {

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import requests
 
 import dask_gateway
 
@@ -14,6 +15,9 @@ class TestCommon:
         client = cluster.get_client()
         cluster.scale(1)
         client.wait_for_workers(1)
+
+        r = requests.get(cluster.dashboard_link)
+        assert r.status_code == 200
 
     def test_has_pc_sdk_subscription_key(self):
         assert "PC_SDK_SUBSCRIPTION_KEY" in os.environ


### PR DESCRIPTION
This was a casuality of the transition to helm_release. We need to set
this as a multi-line string, which didn't go well with `set`.