### PR TITLE
Add kbatch integration to staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ $ az keyvault secret set --vault-name pc-deploy-secrets --name '<prefix>--<key-n
 | pcc--id-client-secret                      | Sets `daskhub.jupyterhub.hub.config.GenericOAuthenticator.client_secret`, an Oauth token to communicate with the pc-id oauth provider                         |
 | pcc--pc-id-token                           | Sets `daskhub.jupyterhub.hub.extraEnv.PC_ID_TOKEN`, an API token with the pc-id application to look up users, enabling the API management integration         |
 | pcc--azure-client-secret                   | Sets `daskhub.jupyterhub.hub.extraEnv.AZURE_CLIENT_SECRET`, an secret key to allow the hub to access Azure resources, enabling the API management integration |
+| pcc-staging--kbatch-server-api-token       | JupyterHub token for the kbatch application in staging.                                                                                                       |
+| pcc-prod--kbatch-server-api-token          | JupyterHub token for the kbatch application in production.                                                                                                    |
+
 
 ## Continuous deployment
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -60,6 +60,9 @@ daskhub:
             - python3
             - /usr/local/jupyterhub_opencensus_monitor.py
           admin: true
+        kbatch:
+          # api_token and URL are set by terraform
+          admin: true
 
       # Volumes for customizing the JupyterHub UI
       # https://discourse.jupyter.org/t/customizing-jupyterhub-on-kubernetes/1769/4

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -26,6 +26,7 @@ module "resources" {
   gpu_pytorch_image                = "pcccr.azurecr.io/public/planetary-computer/gpu-pytorch:2021.09.28.0"
   gpu_tensorflow_image             = "pcccr.azurecr.io/public/planetary-computer/gpu-tensorflow:2021.10.01.11"
   qgis_image                       = "pcccr.azurecr.io/planetary-computer/qgis:3.18.0"
+  kbatch_server_url                = "http://kbatch-server.prod.svc.cluster.local"
 
 }
 

--- a/terraform/resources/hub.tf
+++ b/terraform/resources/hub.tf
@@ -119,4 +119,14 @@ resource "helm_release" "dhub" {
     value = "${var.dns_label}-dask"
   }
 
+  set {
+    name  = "daskhub.jupyterhub.hub.services.kbatch.api_token"
+    value = data.azurerm_key_vault_secret.kbatch_server_api_token.value
+  }
+
+  set {
+    name  = "daskhub.jupyterhub.hub.services.kbatch.url"
+    value = var.kbatch_server_url
+  }
+
 }

--- a/terraform/resources/keyvault.tf
+++ b/terraform/resources/keyvault.tf
@@ -26,3 +26,9 @@ data "azurerm_key_vault_secret" "azure_client_secret" {
   name         = "${local.stack_id}--azure-client-secret"
   key_vault_id = data.azurerm_key_vault.deploy_secrets.id
 }
+
+# kbatch integration
+data "azurerm_key_vault_secret" "kbatch_server_api_token" {
+  name         = "${local.namespaced_prefix}--kbatch-server-api-token"
+  key_vault_id = data.azurerm_key_vault.deploy_secrets.id
+}

--- a/terraform/resources/variables.tf
+++ b/terraform/resources/variables.tf
@@ -131,6 +131,11 @@ variable "user_placeholder_replicas" {
   description = "The number of User placeholder replicas for JupyterHub (see https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/optimization.html#scaling-up-in-time-user-placeholders)."
 }
 
+variable "kbatch_server_url" {
+  type        = string
+  description = "URL (possibly kubernetes-internal) to the kbatch-server application."
+}
+
 # -----------------
 # Local variables
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -26,7 +26,7 @@ module "resources" {
   gpu_pytorch_image                = "pcccr.azurecr.io/public/planetary-computer/gpu-pytorch:2021.09.28.0"
   gpu_tensorflow_image             = "pcccr.azurecr.io/public/planetary-computer/gpu-tensorflow:2021.10.01.11"
   qgis_image                       = "pcccr.azurecr.io/planetary-computer/qgis:3.18.0"
-
+  kbatch_server_url                = "http://kbatch-server.staging.svc.cluster.local"
 }
 
 terraform {


### PR DESCRIPTION
Just a prototype for now.

kbatch is being deployed separately for now (from a local helm chart as I develop it), but this adds the configuration to run it as a JupyterHub service.

In the future, we could add it as a dependency to our chart at https://github.com/microsoft/planetary-computer-hub/blob/main/helm/chart/Chart.yaml, to deploy everything in one shot from here.

