### PR TITLE
Revert "Bump images"

### DIFF
--- a/helm/kbatch-proxy-values.yaml
+++ b/helm/kbatch-proxy-values.yaml
@@ -41,7 +41,7 @@ kbatch-proxy:
                             operator: In
                             values:
                               - user
-            backoffLimit: 0
+            backoffLimit: 1
 
 resources:
   limits:

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -20,11 +20,11 @@ module "resources" {
   user_placeholder_replicas        = 0
   stac_url                         = "https://planetarycomputer-staging.microsoft.com/api/stac/v1/"
   jupyterhub_singleuser_image_name = "pcccr.azurecr.io/public/planetary-computer/python"
-  jupyterhub_singleuser_image_tag  = "2021.11.19.0"
-  python_image                     = "pcccr.azurecr.io/public/planetary-computer/python:2021.11.19.0"
-  r_image                          = "pcccr.azurecr.io/public/planetary-computer/r:2021.11.19.0"
-  gpu_pytorch_image                = "pcccr.azurecr.io/public/planetary-computer/gpu-pytorch:2021.11.19.0"
-  gpu_tensorflow_image             = "pcccr.azurecr.io/public/planetary-computer/gpu-tensorflow:2021.11.19.0"
+  jupyterhub_singleuser_image_tag  = "2021.10.01.11"
+  python_image                     = "pcccr.azurecr.io/public/planetary-computer/python:2021.10.01.11"
+  r_image                          = "pcccr.azurecr.io/public/planetary-computer/r:2021.11.04.0"
+  gpu_pytorch_image                = "pcccr.azurecr.io/public/planetary-computer/gpu-pytorch:2021.09.28.0"
+  gpu_tensorflow_image             = "pcccr.azurecr.io/public/planetary-computer/gpu-tensorflow:2021.10.01.11"
   qgis_image                       = "pcccr.azurecr.io/planetary-computer/qgis:3.18.0"
   kbatch_proxy_url                 = "http://dhub-staging-kbatch-proxy.staging.svc.cluster.local"
 }


### PR DESCRIPTION
Reverts microsoft/planetary-computer-hub#37

This is failing to launch pods with

```
    self.init_webapp()
  File "/srv/conda/envs/notebook/lib/python3.8/site-packages/jupyterhub/singleuser/mixins.py", line 628, in init_webapp
    super().init_webapp()
  File "/srv/conda/envs/notebook/lib/python3.8/site-packages/notebook/notebookapp.py", line 1759, in init_webapp
    self.web_app = NotebookWebApplication(
  File "/srv/conda/envs/notebook/lib/python3.8/site-packages/notebook/notebookapp.py", line 179, in __init__
    settings = self.init_settings(
  File "/srv/conda/envs/notebook/lib/python3.8/site-packages/notebook/notebookapp.py", line 302, in init_settings
    nbextensions_path=jupyter_app.nbextensions_path,
  File "/srv/conda/envs/notebook/lib/python3.8/site-packages/jupyterhub/singleuser/mixins.py", line 412, in nbextensions_path
    path = super().nbextensions_path
  File "/srv/conda/envs/notebook/lib/python3.8/site-packages/notebook/notebookapp.py", line 1329, in nbextensions_path
    from IPython.paths import get_ipython_dir
  File "/srv/conda/envs/notebook/lib/python3.8/site-packages/IPython/__init__.py", line 56, in <module>
    from .terminal.embed import embed
  File "/srv/conda/envs/notebook/lib/python3.8/site-packages/IPython/terminal/embed.py", line 16, in <module>
    from IPython.terminal.interactiveshell import TerminalInteractiveShell
  File "/srv/conda/envs/notebook/lib/python3.8/site-packages/IPython/terminal/interactiveshell.py", line 35, in <module>
    from .debugger import TerminalPdb, Pdb
  File "/srv/conda/envs/notebook/lib/python3.8/site-packages/IPython/terminal/debugger.py", line 9, in <module>
    from .ptutils import IPythonPTCompleter
  File "/srv/conda/envs/notebook/lib/python3.8/site-packages/IPython/terminal/ptutils.py", line 40
    string = string.replace('...','\N{HORIZONTAL ELLIPSIS}')
                                  ^
SyntaxError: (unicode error) \N escapes not supported (can't load unicodedata module)

```