### PR TITLE
Added read-only static volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Defines the variables that can be controlled by the staging / prod deployments. 
 
 Creates the [Azure Virtual Network](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview) used by the Kubernetes Cluster.
 
+### data-volumes.tf
+
+Creates an Azure Storage Account, File share, and Kubernetes Secret for mounting the file share. This is used to mount read-only, static files into all the user
+pods (e.g. a dataset for a machine learning competition).
+
 ## Manual Resources
 
 We rely on a few "manual" resources that are created outside of this repository. These include

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -73,6 +73,7 @@ daskhub:
         - name: hub-external
           configMap:
             name: hub-external
+
       extraVolumeMounts:
         - name: hub-templates
           mountPath: /etc/jupyterhub/templates
@@ -179,12 +180,21 @@ daskhub:
             emptyDir:
               medium: Memory
 
+          - name: driven-data
+            azureFile:
+              secretName: driven-data-file-share
+              shareName: driven-data
+              readOnly: true
+
         extraVolumeMounts:
           - name: user-etc-singleuser
             mountPath: /etc/singleuser
 
-          - mountPath: /dev/shm
-            name: dshm
+          - name: dshm
+            mountPath: /dev/shm
+
+          - name: driven-data
+            mountPath: /driven-data/
 
       extraEnv:
         DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'

--- a/terraform/resources/data-volumes.tf
+++ b/terraform/resources/data-volumes.tf
@@ -1,0 +1,27 @@
+# # Shared volumes for datasets
+
+resource "azurerm_storage_account" "pc-compute" {
+  name                     = "${replace(local.maybe_staging_prefix, "-", "")}storage"
+  resource_group_name      = azurerm_resource_group.pc_compute.name
+  location                 = azurerm_resource_group.pc_compute.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_share" "pc-compute" {
+  name                 = "driven-data"
+  storage_account_name = azurerm_storage_account.pc-compute.name
+  quota                = 100
+}
+
+resource "kubernetes_secret" "pc-compute-fileshare" {
+  metadata {
+    name      = "driven-data-file-share"
+    namespace = var.environment
+  }
+
+  data = {
+    azurestorageaccountname = azurerm_storage_account.pc-compute.name
+    azurestorageaccountkey  = azurerm_storage_account.pc-compute.primary_access_key
+  }
+}

--- a/terraform/resources/hub.tf
+++ b/terraform/resources/hub.tf
@@ -144,4 +144,8 @@ resource "helm_release" "dhub" {
     value = "https://${var.jupyterhub_host}/compute/hub/api/"
   }
 
+  # depends_on = [
+  #   kubernetes_persistent_volume_claim.test-data-shared
+  # ]
+
 }

--- a/terraform/resources/providers.tf
+++ b/terraform/resources/providers.tf
@@ -12,6 +12,14 @@ provider "helm" {
   }
 }
 
+provider "kubernetes" {
+  host                   = azurerm_kubernetes_cluster.pc_compute.kube_config[0].host
+  client_key             = base64decode(azurerm_kubernetes_cluster.pc_compute.kube_config[0].client_key)
+  client_certificate     = base64decode(azurerm_kubernetes_cluster.pc_compute.kube_config[0].client_certificate)
+  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.pc_compute.kube_config[0].cluster_ca_certificate)
+}
+
+
 terraform {
   required_version = ">= 1.0.0"
 
@@ -25,5 +33,11 @@ terraform {
       source  = "hashicorp/random"
       version = "3.0.0"
     }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.6.1"
+    }
+
   }
 }


### PR DESCRIPTION
For supporting ML competitions where a directory of files makes the most sense, we can populate an Azure File share with the files and mount them on each user pod.
