### PR TITLE
Log session durations

### DIFF
--- a/helm/jupyterhub_opencensus_monitor.yaml
+++ b/helm/jupyterhub_opencensus_monitor.yaml
@@ -9,12 +9,15 @@ daskhub:
             Opencensus monitor for JupyterHub as a JupyterHub service.
             """
             import asyncio
+            import datetime
             import logging
+            from typing import Dict, List
             import os
             from collections import Counter, defaultdict
 
             import httpx
             from opencensus.ext.azure import metrics_exporter
+            from opencensus.ext.azure.log_exporter import AzureLogHandler
             import opencensus.stats.aggregation
             import opencensus.stats.view
             import opencensus.stats.stats
@@ -23,10 +26,21 @@ daskhub:
 
 
             logger = logging.getLogger(__name__)
+            logger.setLevel(logging.INFO)
+            handler = logging.StreamHandler()
+            handler.setLevel(logging.INFO)
+            logger.addHandler(handler)
 
+            azlogger = logging.getLogger("pc_metrics")
+            azlogger.setLevel(logging.INFO)
+            handler = AzureLogHandler()
+            handler.setLevel(logging.INFO)
+            azlogger.addHandler(handler)
+
+            DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
             __version__ = "0.1.0"
-            INTERVAL = 60  # seconds
+            INTERVAL = 5  # seconds
 
             # ---- Metrics configuration ----
             # We collect / record by counts by profile, so create one TagMap per profile.
@@ -68,6 +82,29 @@ daskhub:
                 return server_count
 
 
+            def compute_durations(users_start_times: Dict[str, datetime.datetime], data: list) -> List[int]:
+                current_users = {user["name"] for user in data}
+                previous_users = set(users_start_times)
+                dropped_users = previous_users - current_users
+                new_users = current_users - previous_users
+
+                now = datetime.datetime.utcnow()
+                durations = []
+
+                for user in dropped_users:
+                    start_time = users_start_times.pop(user)  # mutates in place!
+                    duration = now - start_time
+                    durations.append(int(duration.total_seconds()))
+
+                for user in data:
+                    if user["name"] in new_users:
+                        # assumes no named servers
+                        server = user["servers"][""]
+                        users_start_times[user["name"]] = datetime.datetime.strptime(server["started"], DATE_FORMAT) 
+
+                return durations
+
+
             async def main():
 
                 JUPYTERHUB_API_TOKEN = os.environ["JUPYTERHUB_API_TOKEN"]
@@ -86,6 +123,8 @@ daskhub:
                         response.json()["version"],
                     )
 
+                    users_start_times: Dict[str, datetime.datetime] = {}
+
                     while True:
                         response = await client.get(
                             f"{JUPYTERHUB_API_URL}/users?state=active", headers=headers
@@ -99,10 +138,14 @@ daskhub:
                             measurement_map.measure_int_put(server_count_measure, count)
                             measurement_map.record(tag_map)
 
+                        durations = compute_durations(users_start_times, data)
+                        print("got durations", durations)
+                        for duration in durations:
+                            azlogger.info("duration %d", duration, extra={"custom_dimensions": {"duration": duration}})
+
                         logger.debug("Sleeping for %d", INTERVAL)
                         await asyncio.sleep(INTERVAL)
 
 
             if __name__ == "__main__":
                 asyncio.run(main())
-

--- a/helm/jupyterhub_opencensus_monitor.yaml
+++ b/helm/jupyterhub_opencensus_monitor.yaml
@@ -24,6 +24,7 @@ daskhub:
 
             logger = logging.getLogger(__name__)
 
+
             __version__ = "0.1.0"
             INTERVAL = 60  # seconds
 
@@ -104,3 +105,4 @@ daskhub:
 
             if __name__ == "__main__":
                 asyncio.run(main())
+

--- a/helm/jupyterhub_opencensus_monitor.yaml
+++ b/helm/jupyterhub_opencensus_monitor.yaml
@@ -23,9 +23,6 @@ daskhub:
 
 
             logger = logging.getLogger(__name__)
-            logger.info(os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"])
-            print(os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"])
-
 
             __version__ = "0.1.0"
             INTERVAL = 60  # seconds

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -81,34 +81,6 @@ daskhub:
           mountPath: /usr/local/share/jupyterhub/static/external
 
       extraConfig:
-        00-spawner-class: |
-          # Custom spawner class to log the duration of the singleuser session
-          import datetime
-          import logging
-
-          from opencensus.ext.azure.log_exporter import AzureLogHandler
-          from kubespawner import KubeSpawner
-
-          logger = logging.getLogger("pc_metrics")
-          handler = AzureLogHandler()
-          handler.setLevel(logging.INFO)
-          logger.setLevel(logging.INFO)
-          logger.addHandler(handler)
-
-          class MyKubeSpawner(KubeSpawner):
-              async def stop(self, now=False):
-                  try:
-                      pod = await self.asynchronize(self.api.read_namespaced_pod, name=self.pod_name, namespace=self.namespace)
-                      now = datetime.datetime.now(datetime.timezone.utc)
-                      duration = int((now -pod.status.start_time).total_seconds())
-                      logger.info("singleuser stop", extra={"custom_dimensions": {"duration": duration}})
-                  except Exception:
-                      logger.exception("Failed to compute pod duration")
-
-                  return await super().stop(now=now)
-
-          c.JupyterHub.spawner_class = MyKubeSpawner
-
         mylabels: |
           c.KubeSpawner.extra_labels = {}
         kubespawner: |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -81,6 +81,34 @@ daskhub:
           mountPath: /usr/local/share/jupyterhub/static/external
 
       extraConfig:
+        00-spawner-class: |
+          # Custom spawner class to log the duration of the singleuser session
+          import datetime
+          import logging
+
+          from opencensus.ext.azure.log_exporter import AzureLogHandler
+          from kubespawner import KubeSpawner
+
+          logger = logging.getLogger("pc_metrics")
+          handler = AzureLogHandler()
+          handler.setLevel(logging.INFO)
+          logger.setLevel(logging.INFO)
+          logger.addHandler(handler)
+
+          class MyKubeSpawner(KubeSpawner):
+              async def stop(self, now=False):
+                  try:
+                      pod = await self.asynchronize(self.api.read_namespaced_pod, name=self.pod_name, namespace=self.namespace)
+                      now = datetime.datetime.now(datetime.timezone.utc)
+                      duration = int((now -pod.status.start_time).total_seconds())
+                      logger.info("singleuser stop", extra={"custom_dimensions": {"duration": duration}})
+                  except Exception:
+                      logger.exception("Failed to compute pod duration")
+
+                  return await super().stop(now=now)
+
+          c.JupyterHub.spawner_class = MyKubeSpawner
+
         mylabels: |
           c.KubeSpawner.extra_labels = {}
         kubespawner: |

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -8,7 +8,7 @@ module "resources" {
   kubernetes_version = "1.21.2"
   # 2GiB of RAM, 1 CPU core
   core_vm_size              = "Standard_A2_v2"
-  user_pool_min_count       = 1
+  user_pool_min_count       = 0
   cpu_worker_pool_min_count = 0
 
   # Logs ---------------------------------------------------------------------


### PR DESCRIPTION
This captures the duration of singleuser sessions. 8d01ccaf5c1b005002ba8146407f1cc5ebbb4b33 was an initial attempt that used a Kubespawner subclass. It was OK, but I'm wary to put too much complexity in the core spawner.

So 7e072767f5e2dcc54c661ed15c331434d59e735a, which we'll go with, captures the metrics as a JupyterHub service. We periodically (minutely) poll the active users endpoint. We have a bit of in-process state, which are the currently active users and their start times. When a user is no longer active, we compute a duration and log it to application insights.