### PR TITLE
Staging Hub uses staging auth.

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -30,9 +30,9 @@ daskhub:
           # oauth_callback_url, client_secret are set via terraform.
           client_id: "YRKd72gJAcBEQMyyz8QnT9luJNKoRcCnF7TL4ffx"
           login_service: 'planetarycomputer'
-          userdata_url: 'https://planetarycomputer.microsoft.com/id/users/userdata'
-          token_url: 'https://planetarycomputer.microsoft.com/id/o/token/'
-          authorize_url: 'https://planetarycomputer.microsoft.com/id/o/authorize/'
+          userdata_url: 'https://${oauth_host}.microsoft.com/id/users/userdata'
+          token_url: 'https://${oauth_host}.microsoft.com/id/o/token/'
+          authorize_url: 'https://${oauth_host}.microsoft.com/id/o/authorize/'
           username_key: 'email'
           userdata_method: 'GET'
 

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -16,6 +16,7 @@ module "resources" {
 
   # DaskHub ------------------------------------------------------------------
   dns_label                 = "pccompute"
+  oauth_host                = "planetarycomputer"
   jupyterhub_host           = "pccompute.westeurope.cloudapp.azure.com"
   user_placeholder_replicas = 1
   stac_url                  = "https://planetarycomputer.microsoft.com/api/stac/v1/"

--- a/terraform/resources/hub.tf
+++ b/terraform/resources/hub.tf
@@ -18,7 +18,7 @@ resource "helm_release" "dhub" {
   create_namespace = true
 
   values = [
-    "${templatefile("../../helm/values.yaml", { jupyterhub_host = var.jupyterhub_host, namespace = var.environment })}",
+    "${templatefile("../../helm/values.yaml", { oauth_host = var.oauth_host, jupyterhub_host = var.jupyterhub_host, namespace = var.environment })}",
     "${file("../../helm/jupyterhub_opencensus_monitor.yaml")}",
     "${templatefile("../../helm/profiles.yaml", { python_image = var.python_image, r_image = var.r_image, gpu_pytorch_image = var.gpu_pytorch_image, gpu_tensorflow_image = var.gpu_tensorflow_image, qgis_image = var.qgis_image })}",
     # workaround https://github.com/hashicorp/terraform-provider-helm/issues/669

--- a/terraform/resources/variables.tf
+++ b/terraform/resources/variables.tf
@@ -16,6 +16,11 @@ variable "kubernetes_version" {
   description = "The Kubernetes version. Used in `aks.tf` in several places."
 }
 
+variable "oauth_host" {
+  type        = string
+  description = "The hostname of the oauth2 provider."
+}
+
 variable "jupyterhub_host" {
   type        = string
   description = "The hostname (no protocol, no hub prefix) for JupyterHub."

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -16,6 +16,7 @@ module "resources" {
 
   # DaskHub ------------------------------------------------------------------
   dns_label                 = "pcc-staging"
+  oauth_host                = "planetarycomputer-staging"
   jupyterhub_host           = "pcc-staging.westeurope.cloudapp.azure.com"
   user_placeholder_replicas = 0
   stac_url                  = "https://planetarycomputer-staging.microsoft.com/api/stac/v1/"


### PR DESCRIPTION
We had some downtime, in part due to a mistaken belief that our staging
hub was using our staging ID application.

This updates the terraform and Hub config to point to
planetary-computer-staging for authentication.