### PR TITLE
Set maximum age on the pods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
 - repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.17.0
+  rev: v1.26.3
   hooks:
     - id: yamllint
       args: [-c=.yamllint.yaml]

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -19,6 +19,10 @@ daskhub:
         name: pcccr.azurecr.io/jupyterhub/k8s-hub
         tag: "1.0.1.post0"
 
+      cull:
+        enabled: true
+        maxAge: 64800  # 18 hours
+
       config:
         JupyterHub:
           admin_access: false

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,7 +21,7 @@ daskhub:
 
       cull:
         enabled: true
-        maxAge: 64800  # 18 hours
+        maxAge: 86400  # 24 hours
 
       config:
         JupyterHub:


### PR DESCRIPTION
We're noticing a large number of seemingly "idle" pods (low CPU / memory utilization). I'm adding a maximum age to cull all pods after a number of hours.

We have [kbatch](https://kbatch.readthedocs.io/) deployed for long-running batch workflows.