### PR TITLE
Request gpu=0 for non-GPU profiles

### DIFF
--- a/helm/profiles.yaml
+++ b/helm/profiles.yaml
@@ -12,6 +12,7 @@ daskhub:
             cpu_limit: 4
             mem_guarantee: "25G"
             mem_limit: "32G"
+            extra_resource_limits: {"nvidia.com/gpu": "0"}
             default_url: "/lab/tree/PlanetaryComputerExamples/README.md"
             node_affinity_required:
               - matchExpressions:
@@ -29,6 +30,7 @@ daskhub:
             cpu_limit: 8
             mem_guarantee: "54G"
             mem_limit: "59G"
+            extra_resource_limits: {"nvidia.com/gpu": "0"}
             default_url: "/lab/tree/PlanetaryComputerExamples/README.md"
             node_affinity_required:
               - matchExpressions:
@@ -101,6 +103,7 @@ daskhub:
             cpu_limit: 4
             mem_guarantee: "24G"
             mem_limit: "30G"
+            extra_resource_limits: {"nvidia.com/gpu": "0"}
             default_url: "/desktop"
             node_affinity_required:
               - matchExpressions:


### PR DESCRIPTION
It seems there's some process level state in Kubespawner that persists
between spawn attempts. We've observed users requesting a GPU profile,
the spawn failing (thanks to hitting our GPU quota) and then subsequent
spawns failing because they're requesting `nvidia.com/gpu=1`, even for
non-GPU profiles.

To attempt to fix this, we always set a request for nvidia.com/gpu.
We explicitly set it to 0 for non-gpu profiles.

Possibly fixes https://github.com/microsoft/PlanetaryComputer/issues/63.