### PR TITLE
Increase the timeout for the notebook server

### DIFF
--- a/helm/chart/config.yaml
+++ b/helm/chart/config.yaml
@@ -88,7 +88,7 @@ daskhub:
         # mylabels: |
         #   c.KubeSpawner.extra_labels = {}
         kubespawner: |
-          c.KubeSpawner.start_timeout = 15 * 60  # 15 minutes
+          c.KubeSpawner.start_timeout = 20 * 60  # 20 minutes
         01-add-dask-gateway-values: |
           # The daskhub helm chart doesn't correctly handle hub.baseUrl.
           # DASK_GATEWAY__PUBLIC_ADDRESS set via terraform


### PR DESCRIPTION
Our GPU nodes appear to be scaling slower than expected. Bumping this timeout to give them a bit more time to appear.