### PR TITLE
Set traefik type to ClusterIP

### DIFF
--- a/helm/chart/config.yaml
+++ b/helm/chart/config.yaml
@@ -452,7 +452,7 @@ daskhub:
             c.Backend.cluster_options = cluster_options
     traefik:
       service:
-        type: LoadBalancer
+        type: ClusterIP
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This traefik endpoint is failing a security check that requires TLS 1.2 or greater on public endpoints. I tried for a while to figure out the right incantations to get traefik to reject TLS 1.1 and earlier (and no TLS) but couldn't figure it out.

For now, changing this to a Cluster IP.