### PR TITLE
Update GPU node pools to Azure Linux

### DIFF
--- a/scripts/gpu
+++ b/scripts/gpu
@@ -12,26 +12,26 @@ export GPU_NODE_VM_SIZE=Standard_NC4as_T4_v3
 
 # TODO(https://github.com/terraform-providers/terraform-provider-azurerm/issues/6793)
 # Add to terraform. Requires --aks-custom-headers support
-az aks nodepool add --name gpuworker \
+az aks nodepool add --name azgpuworker \
     --cluster-name ${CLUSTER_NAME} \
     --resource-group ${RESOURCE_GROUP_NAME} \
     --node-vm-size ${GPU_NODE_VM_SIZE} \
+    --os-sku AzureLinux \
     --enable-cluster-autoscaler \
     --node-count 0 \
     --min-count=0 --max-count 25 \
     --priority Spot \
     --eviction-policy Delete \
     --spot-max-price -1 \
-    --aks-custom-headers UseGPUDedicatedVHD=true \
     --labels k8s.dask.org/dedicated=worker pc.microsoft.com/workerkind=gpu
 # User GPU pool
-az aks nodepool add --name gpuuser \
+az aks nodepool add --name azgpuuser \
     --cluster-name ${CLUSTER_NAME} \
     --resource-group ${RESOURCE_GROUP_NAME} \
     --node-vm-size ${GPU_NODE_VM_SIZE} \
+    --os-sku AzureLinux \
     --enable-cluster-autoscaler \
     --node-count 0 \
     --min-count=0 --max-count 25 \
-    --aks-custom-headers UseGPUDedicatedVHD=true \
     --labels hub.jupyter.org/node-purpose=user hub.jupyter.org/pool-name=user-alpha-pool pc.microsoft.com/userkind=gpu \
     --node-taints "hub.jupyter.org_dedicated=user:NoSchedule"

--- a/scripts/nvidia-device-plugin-ds-staging.yaml
+++ b/scripts/nvidia-device-plugin-ds-staging.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nvidia-device-plugin-daemonset
-  namespace: prod
+  namespace: staging
 spec:
   selector:
     matchLabels:

--- a/scripts/nvidia-device-plugin-ds.yaml
+++ b/scripts/nvidia-device-plugin-ds.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: prod
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-ds
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: nvidia-device-plugin-ds
+    spec:
+      priorityClassName: "system-cluster-critical"
+      tolerations:
+      # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
+      # This, along with the annotation above marks this pod as a critical add-on.
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: "sku"
+        operator: "Equal"
+        value: "gpu"
+        effect: "NoSchedule"
+      containers:
+      - image: mcr.microsoft.com/oss/nvidia/k8s-device-plugin:v0.14.1
+        name: nvidia-device-plugin-ctr
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+          - name: device-plugin
+            mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+


### PR DESCRIPTION
Updates the GPU node pools to Azure Linux.

We couldn't use the `--aks-custom-headers UseGPUDedicatedVHD=true` with Azure Linux. The included daemonset seems to accomplish the same thing. That was applied with kubectl manually.