### PR TITLE
Uses managed identity for API Management access

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ $ az keyvault secret set --vault-name pc-deploy-secrets --name '<prefix>--<key-n
 | pcc-prod--jupyterhub-proxy-secret-token    | Sets `daskhub.jupyterhub.proxy.secretToken` for the prod JupyterHub                                                                                           |
 | pcc--id-client-secret                      | Sets `daskhub.jupyterhub.hub.config.GenericOAuthenticator.client_secret`, an Oauth token to communicate with the pc-id oauth provider                         |
 | pcc--pc-id-token                           | Sets `daskhub.jupyterhub.hub.extraEnv.PC_ID_TOKEN`, an API token with the pc-id application to look up users, enabling the API management integration         |
-| pcc--azure-client-secret                   | Sets `daskhub.jupyterhub.hub.extraEnv.AZURE_CLIENT_SECRET`, an secret key to allow the hub to access Azure resources, enabling the API management integration |
 | pcc-staging--kbatch-server-api-token       | JupyterHub token for the kbatch application in staging.                                                                                                       |
 | pcc-prod--kbatch-server-api-token          | JupyterHub token for the kbatch application in production.                                                                                                    |
 | pcc--velero-azure-subscription-id          | Set in `velero_credentials.tpl` for backups / migrations                                                                                                      |

--- a/helm/chart/config.yaml
+++ b/helm/chart/config.yaml
@@ -20,6 +20,15 @@ daskhub:
         name: pcccr.azurecr.io/jupyterhub/k8s-hub
         tag: "1.0.1.post0"
 
+      labels:
+        azure.workload.identity/use: "true"
+
+      # Ensure the hub service account is created and used. The annotation to
+      # attach a managed identity is set in terraform.
+      serviceAccount:
+        create: true
+        name: hub
+
       networkPolicy:
         ingress:
           - ports:
@@ -50,11 +59,8 @@ daskhub:
           username_key: 'email'
           userdata_method: 'GET'
 
-      extraEnv:
-        # This service principal has read permission on Azure API management.
-        AZURE_TENANT_ID: "72f988bf-86f1-41af-91ab-2d7cd011db47"
-        AZURE_CLIENT_ID: "185e2bd5-f11e-490c-8849-7889951120b4"
-        # AZURE_CLIENT_SECRET, PC_ID_TOKEN, APPLICATIONINSIGHTS_CONNECTION_STRING are set via terraform
+#      extraEnv:
+        # PC_ID_TOKEN, APPLICATIONINSIGHTS_CONNECTION_STRING are set via terraform
 
       extraFiles:
         jupyterhub_opencensus_monitor:

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -6,6 +6,8 @@ module "resources" {
   maybe_versioned_prefix = "pcc-prod-2"
   # subscription = "Planetary Computer"
 
+  apim_resource_id = "/subscriptions/9da7523a-cb61-4c3e-b1d4-afa5fc6d2da9/resourceGroups/pc-manual-resources/providers/Microsoft.ApiManagement/service/planetarycomputer"
+
   # AKS ----------------------------------------------------------------------
   kubernetes_version                                   = null
   aks_azure_active_directory_role_based_access_control = true

--- a/terraform/resources/hub.tf
+++ b/terraform/resources/hub.tf
@@ -35,6 +35,11 @@ resource "helm_release" "dhub" {
   # }
 
   set {
+    name  = "daskhub.jupyterhub.hub.serviceAccount.annotations.azure\\.workload\\.identity/client-id"
+    value = azurerm_user_assigned_identity.hub.client_id
+  }
+
+  set {
     name  = "daskhub.jupyterhub.hub.config.GenericOAuthenticator.oauth_callback_url"
     value = "https://${var.jupyterhub_host}/compute/hub/oauth_callback"
   }
@@ -42,11 +47,6 @@ resource "helm_release" "dhub" {
   set {
     name  = "daskhub.jupyterhub.hub.config.GenericOAuthenticator.client_secret"
     value = data.azurerm_key_vault_secret.id_client_secret.value
-  }
-
-  set {
-    name  = "daskhub.jupyterhub.hub.extraEnv.AZURE_CLIENT_SECRET"
-    value = data.azurerm_key_vault_secret.azure_client_secret.value
   }
 
   set {
@@ -119,7 +119,6 @@ resource "helm_release" "dhub" {
     name  = "daskhub.dask-gateway.traefik.service.annotations.service\\.beta\\.kubernetes\\.io/azure-dns-label-name"
     value = "${var.dns_label}-dask"
   }
-
 }
 
 data "azurerm_storage_account" "pc-compute" {

--- a/terraform/resources/keyvault.tf
+++ b/terraform/resources/keyvault.tf
@@ -21,12 +21,6 @@ data "azurerm_key_vault_secret" "pc_id_token" {
   key_vault_id = data.azurerm_key_vault.deploy_secrets.id
 }
 
-# API Management integration
-data "azurerm_key_vault_secret" "azure_client_secret" {
-  name         = "${local.stack_id}--azure-client-secret"
-  key_vault_id = data.azurerm_key_vault.deploy_secrets.id
-}
-
 data "azurerm_key_vault_secret" "microsoft_defender_log_analytics_workspace_id" {
   name         = "${local.stack_id}--microsoft-defender-log-analytics-workspace-id"
   key_vault_id = data.azurerm_key_vault.deploy_secrets.id

--- a/terraform/resources/outputs.tf
+++ b/terraform/resources/outputs.tf
@@ -11,11 +11,6 @@ output "id_client_secret" {
   sensitive = true
 }
 
-output "azure_client_secret" {
-  value     = data.azurerm_key_vault_secret.azure_client_secret.value
-  sensitive = true
-}
-
 output "pc_id_token" {
   value     = data.azurerm_key_vault_secret.pc_id_token.value
   sensitive = true

--- a/terraform/resources/variables.tf
+++ b/terraform/resources/variables.tf
@@ -89,6 +89,11 @@ variable "qgis_image" {
   description = "The tag for the QGIS environment image."
 }
 
+variable "apim_resource_id" {
+  type        = string
+  description = "The resource ID for the API Management service."
+}
+
 # ----------------------------------------------------------------------------
 # AKS
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -6,6 +6,8 @@ module "resources" {
   maybe_versioned_prefix = "pcc-staging-2"
   # subscription = "Planetary Computer"
 
+  apim_resource_id = "/subscriptions/9da7523a-cb61-4c3e-b1d4-afa5fc6d2da9/resourceGroups/pc-manual-resources/providers/Microsoft.ApiManagement/service/planetarycomputer"
+
   # AKS ----------------------------------------------------------------------
   kubernetes_version                                   = null
   aks_azure_active_directory_role_based_access_control = true


### PR DESCRIPTION
Switches from using a service principal to using a managed identity when the hub attempts to retrieve information from API Management. A managed identity is created and given permissions on the API Management service. Then a federated identity credential is created to map the managed identity onto a service account, which is the service account used by the jupyterhub hub pod. This service account is annotated with the managed identity client ID, and the hub pod is labelled to enable azure workload identity.