### PR TITLE
Use Application Gateway Ingress Controller

### DIFF
--- a/helm/chart/config.yaml
+++ b/helm/chart/config.yaml
@@ -13,9 +13,13 @@ daskhub:
         nodeAffinity:
           matchNodePurpose: "require"
 
+    ingress:
+      enabled: true
+      ingressClassName: "azure-application-gateway"
+
     hub:
       consecutiveFailureLimit: 0
-      baseUrl: "/compute/"
+      baseUrl: "/"
       image:
         name: pcccr.azurecr.io/jupyterhub/k8s-hub
         tag: "2.0.0.post0"
@@ -107,8 +111,8 @@ daskhub:
         01-add-dask-gateway-values: |
           # The daskhub helm chart doesn't correctly handle hub.baseUrl.
           # DASK_GATEWAY__PUBLIC_ADDRESS set via terraform
-          c.KubeSpawner.environment["DASK_GATEWAY__ADDRESS"] = "http://proxy-http:8000/compute/services/dask-gateway/"
-          c.KubeSpawner.environment["DASK_GATEWAY__PUBLIC_ADDRESS"] = "https://${jupyterhub_host}/compute/services/dask-gateway/"
+          c.KubeSpawner.environment["DASK_GATEWAY__ADDRESS"] = "http://proxy-http:8000/services/dask-gateway/"
+          c.KubeSpawner.environment["DASK_GATEWAY__PUBLIC_ADDRESS"] = "https://${jupyterhub_host}/services/dask-gateway/"
         templates: |
           c.JupyterHub.template_paths.insert(0, "/etc/jupyterhub/templates")
         pre_spawn_hook: |
@@ -172,9 +176,9 @@ daskhub:
 
     proxy:
       https:
-        enabled: true
-        letsencrypt:
-          contactEmail: "taugspurger@microsoft.com"
+        enabled: false
+        # letsencrypt:
+        #   contactEmail: "taugspurger@microsoft.com"
 
       chp:
         networkPolicy:
@@ -272,11 +276,11 @@ daskhub:
 
   dask-gateway:
     gateway:
-      prefix: "/compute/services/dask-gateway"
+      prefix: "/services/dask-gateway"
       auth:
         jupyterhub:
           apiToken: "{{ tf.jupyterhub_dask_gateway_token }}"
-          apiUrl: http://proxy-http:8000/compute/hub/api
+          apiUrl: http://proxy-http:8000/hub/api
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/helm/tls.yaml
+++ b/helm/tls.yaml
@@ -1,0 +1,7 @@
+daskhub:
+  jupyterhub:
+    ingress:
+      enabled: true
+      ingressClassName: "azure-application-gateway"
+      tls:
+        - secretName: "${secret_name}"

--- a/scripts/agic-cert-secret
+++ b/scripts/agic-cert-secret
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import base64
+import os
+import subprocess
+import azure.identity
+import azure.keyvault.secrets
+import kr8s
+import argparse
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--keyvault-name", required=True)
+    parser.add_argument("--namespace", required=True)
+    parser.add_argument("--secret-name", required=True)
+
+    return parser.parse_args(args)
+
+
+def main(args=None):
+    args = parse_args(args)
+
+    keyvault_name = args.keyvault_name
+    namespace = args.namespace
+    secret_name = args.secret_name
+
+    credential = azure.identity.DefaultAzureCredential()
+    kv_client = azure.keyvault.secrets.SecretClient(
+        f"https://{keyvault_name}.vault.azure.net", credential=credential
+    )
+
+    secret = kv_client.get_secret(secret_name)
+    decoded = base64.b64decode(secret.value)
+
+    pfx = "certificate.pfx"
+    key = "private.key"
+    crt = "certificate.crt"
+
+    with open(pfx, "wb") as f:
+        f.write(decoded)
+
+    cmd = f"openssl pkcs12 -in {pfx} -nocerts -nodes -passin pass: | openssl rsa -out {key}"
+
+    print("processing certificate")
+    subprocess.run(cmd, shell=True)
+    subprocess.run(
+        [
+            "openssl",
+            "pkcs12",
+            "-in",
+            pfx,
+            "-clcerts",
+            "-nokeys",
+            "-passin",
+            "pass:",
+            "-out",
+            crt,
+        ]
+    )
+
+    print("creating secret")
+    subprocess.run(
+        [
+            "kubectl",
+            "-n",
+            namespace,
+            "create",
+            "secret",
+            "tls",
+            secret_name,
+            "--cert",
+            crt,
+            "--key",
+            key,
+        ]
+    )
+
+    os.remove(pfx)
+    os.remove(crt)
+    os.remove(key)
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -7,6 +7,12 @@ module "resources" {
   # subscription = "Planetary Computer"
 
   apim_resource_id = "/subscriptions/9da7523a-cb61-4c3e-b1d4-afa5fc6d2da9/resourceGroups/pc-manual-resources/providers/Microsoft.ApiManagement/service/planetarycomputer"
+  # TLS certs
+  certificate_kv          = "pc-deploy-secrets"
+  certificate_kv_rg       = "pc-manual-resources"
+  certificate_secret_name = "planetarycomputer-hub-staging"
+  pip_name                = "pip-pcc-prod"
+  appgw_name              = "appgw-pcc-prod"
 
   # AKS ----------------------------------------------------------------------
   kubernetes_version                                   = null
@@ -25,7 +31,7 @@ module "resources" {
   # DaskHub ------------------------------------------------------------------
   dns_label                 = "pccompute"
   oauth_host                = "planetarycomputer"
-  jupyterhub_host           = "pccompute.westeurope.cloudapp.azure.com"
+  jupyterhub_host           = "planetarycomputer-hub.microsoft.com"
   user_placeholder_replicas = 1
   stac_url                  = "https://planetarycomputer.microsoft.com/api/stac/v1/"
 

--- a/terraform/resources/aks.tf
+++ b/terraform/resources/aks.tf
@@ -46,7 +46,12 @@ resource "azurerm_kubernetes_cluster" "pc_compute" {
     }
 
     orchestrator_version        = var.kubernetes_version
-    temporary_name_for_rotation = "tmpdefault"
+    temporary_name_for_rotation = "azlinuxpool"
+
+    upgrade_settings {
+      max_surge = "10%"
+    }
+
   }
 
   auto_scaler_profile {
@@ -56,6 +61,15 @@ resource "azurerm_kubernetes_cluster" "pc_compute" {
     scale_down_delay_after_add  = "5m"
     skip_nodes_with_system_pods = false # ensures system pods don't keep GPU nodes alive
   }
+
+  ingress_application_gateway {
+    gateway_id = data.azurerm_application_gateway.pc_compute.id
+  }
+
+  key_vault_secrets_provider {
+    secret_rotation_enabled = true
+  }
+
   identity {
     type = "SystemAssigned"
   }

--- a/terraform/resources/keyvault.tf
+++ b/terraform/resources/keyvault.tf
@@ -1,6 +1,19 @@
 data "azurerm_key_vault" "deploy_secrets" {
   name                = var.pc_resources_kv
   resource_group_name = var.pc_resources_rg
+  provider            = azurerm.pc
+}
+
+data "azurerm_key_vault" "certificate" {
+  name                = var.certificate_kv
+  resource_group_name = var.certificate_kv_rg
+}
+
+
+data "azurerm_key_vault" "test_deploy_secrets" {
+  name                = "pc-test-deploy-secrets"
+  resource_group_name = "pc-test-manual-resources"
+  provider            = azurerm.pct
 }
 
 # JupyterHub
@@ -24,4 +37,27 @@ data "azurerm_key_vault_secret" "pc_id_token" {
 data "azurerm_key_vault_secret" "microsoft_defender_log_analytics_workspace_id" {
   name         = "${local.stack_id}--microsoft-defender-log-analytics-workspace-id"
   key_vault_id = data.azurerm_key_vault.deploy_secrets.id
+}
+
+data "azurerm_key_vault_certificate" "pccompute" {
+  name         = "planetarycomputer-hub-test"
+  key_vault_id = data.azurerm_key_vault.test_deploy_secrets.id
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault_access_policy" "secret-reader" {
+  key_vault_id = data.azurerm_key_vault.test_deploy_secrets.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_kubernetes_cluster.pc_compute.key_vault_secrets_provider[0].secret_identity[0].object_id
+
+  secret_permissions = [
+    "Get",
+  ]
+  certificate_permissions = [
+    "Get",
+  ]
+  key_permissions = [
+    "Get",
+  ]
 }

--- a/terraform/resources/mi.tf
+++ b/terraform/resources/mi.tf
@@ -1,0 +1,11 @@
+resource "azurerm_user_assigned_identity" "pc_compute" {
+  location            = azurerm_resource_group.pc_compute.location
+  resource_group_name = azurerm_resource_group.pc_compute.name
+  name                = "${local.stack_id}-mi"
+}
+
+resource "azurerm_role_assignment" "pccompute" {
+  scope                = data.azurerm_key_vault.deploy_secrets.id
+  principal_id         = azurerm_user_assigned_identity.pc_compute.principal_id
+  role_definition_name = "Key Vault Certificate User"
+}

--- a/terraform/resources/providers.tf
+++ b/terraform/resources/providers.tf
@@ -2,6 +2,22 @@ provider "azurerm" {
   features {}
 }
 
+provider "azurerm" {
+  subscription_id = "9da7523a-cb61-4c3e-b1d4-afa5fc6d2da9"
+  alias           = "pc"
+
+  features {}
+}
+
+
+provider "azurerm" {
+  subscription_id = "a84a690d-585b-4c7c-80d9-851a48af5a50"
+  alias           = "pct"
+
+  features {}
+}
+
+
 provider "helm" {
   # https://dev.to/danielepolencic/getting-started-with-terraform-and-kubernetes-on-azure-aks-3l4d
   kubernetes {
@@ -58,7 +74,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "2.6.0"
+      version = "2.13.2"
     }
 
   }

--- a/terraform/resources/variables.tf
+++ b/terraform/resources/variables.tf
@@ -157,6 +157,29 @@ variable "pc_resources_kv" {
   description = "The Azure Key Vault name with pre-configured values."
 }
 
+variable "certificate_kv" {
+  type        = string
+  description = "The name of the Key Vault with the public certificate used for TLS."
+}
+
+variable "certificate_kv_rg" {
+  type        = string
+  description = "The name of the Resource Group with the Key Vault with the public certificate used for TLS."
+}
+
+variable "certificate_secret_name" {
+  type = string
+}
+
+variable "pip_name" {
+  type = string
+}
+
+variable "appgw_name" {
+  type = string
+}
+
+
 variable "user_placeholder_replicas" {
   type        = number
   default     = 0

--- a/terraform/shared/main.tf
+++ b/terraform/shared/main.tf
@@ -37,6 +37,7 @@ resource "azurerm_resource_group" "shared" {
   tags = {
     "ringValue" = "r1"
   }
+  provider = azurerm.pc
 }
 
 resource "azurerm_storage_account" "pc-compute" {

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -1,18 +1,17 @@
 module "resources" {
   source                 = "../resources"
-  environment            = "staging"
+  environment            = "test"
   region                 = "West Europe"
   version_number         = "2"
-  maybe_versioned_prefix = "pcc-staging-2"
-  # subscription = "Planetary Computer"
+  maybe_versioned_prefix = "pcc-test"
 
   apim_resource_id = "/subscriptions/9da7523a-cb61-4c3e-b1d4-afa5fc6d2da9/resourceGroups/pc-manual-resources/providers/Microsoft.ApiManagement/service/planetarycomputer"
   # TLS certs
-  certificate_kv          = "pc-deploy-secrets"
-  certificate_kv_rg       = "pc-manual-resources"
-  certificate_secret_name = "planetarycomputer-hub-staging"
-  pip_name                = "pip-pcc-staging"
-  appgw_name              = "appgw-pcc-staging"
+  certificate_kv          = "pc-test-deploy-secrets"
+  certificate_kv_rg       = "pc-test-manual-resources"
+  certificate_secret_name = "planetarycomputer-hub-test"
+  pip_name                = "pccompute-public-ip"
+  appgw_name              = "pccompute-appgateway"
 
   # AKS ----------------------------------------------------------------------
   kubernetes_version                                   = null
@@ -29,9 +28,9 @@ module "resources" {
   workspace_id = "83dcaf36e047a90f"
 
   # DaskHub ------------------------------------------------------------------
-  dns_label                 = "pcc-staging"
+  dns_label                 = "planetarycomputer-hub-test"
   oauth_host                = "planetarycomputer-staging"
-  jupyterhub_host           = "planetarycomputer-hub-staging.microsoft.com"
+  jupyterhub_host           = "planetarycomputer-hub-test.microsoft.com"
   user_placeholder_replicas = 0
   stac_url                  = "https://planetarycomputer-staging.microsoft.com/api/stac/v1/"
 
@@ -42,15 +41,14 @@ module "resources" {
   gpu_pytorch_image                = "pcccr.azurecr.io/planetary-computer/gpu-pytorch:2024.3.22.0"
   gpu_tensorflow_image             = "pcccr.azurecr.io/planetary-computer/gpu-tensorflow:2024.3.22.0"
   qgis_image                       = "pcccr.azurecr.io/planetary-computer/qgis:2024.3.19.7"
-
 }
 
 terraform {
   backend "azurerm" {
-    resource_group_name  = "pc-manual-resources"
-    storage_account_name = "pctfstate"
+    resource_group_name  = "pc-test-manual-resources"
+    storage_account_name = "pctesttfstate"
     container_name       = "pcc"
-    key                  = "staging-2.tfstate"
+    key                  = "pcc.tfstate"
   }
 }
 


### PR DESCRIPTION
This puts AGIC as the ingress controller on the Hub. Some consequences:

1. We get a real hostname (planetarycomputer-hub*.microsoft.com)
2. We can drop the `/compute` prefix. The Hub is served at `/hub`.

Note that this change *requires* the upgrade to JupyterHub to make use of the `ingressClassName` attribute.