### PR TITLE
Fixed prod secret name

### DIFF
--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -10,7 +10,7 @@ module "resources" {
   # TLS certs
   certificate_kv          = "pc-deploy-secrets"
   certificate_kv_rg       = "pc-manual-resources"
-  certificate_secret_name = "planetarycomputer-hub-prod"
+  certificate_secret_name = "planetarycomputer-hub-production"
   pip_name                = "pip-pcc-prod"
   appgw_name              = "appgw-pcc-prod"
 

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -10,7 +10,7 @@ module "resources" {
   # TLS certs
   certificate_kv          = "pc-deploy-secrets"
   certificate_kv_rg       = "pc-manual-resources"
-  certificate_secret_name = "planetarycomputer-hub-staging"
+  certificate_secret_name = "planetarycomputer-hub-prod"
   pip_name                = "pip-pcc-prod"
   appgw_name              = "appgw-pcc-prod"
 


### PR DESCRIPTION
Seeing this in the app gateway pods

```
Event(v1.ObjectReference{Kind:"Ingress", Namespace:"prod",
Name:"jupyterhub", UID:"5aa72907-dbdf-4c79-a8f3-f0867ffe9150",
APIVersion:"networking.k8s.io/v1", ResourceVersion:"700396216",
FieldPath:""}): type: 'Warning' reason: 'SecretNotFound' Unable to find
the secret associated to secretId: [prod/planetarycomputer-hub-staging]
```

Causing 502s.